### PR TITLE
Fix draw past end of buffer

### DIFF
--- a/Display.cpp
+++ b/Display.cpp
@@ -236,7 +236,7 @@ void	Display::loop()
 	glBindBuffer(GL_ARRAY_BUFFER, vbo);
 	glBufferData(GL_ARRAY_BUFFER, 6 * nv * sizeof(float),
 		out, GL_STATIC_DRAW);
-	glDrawArrays(GL_TRIANGLES, 0, nv * 3);
+	glDrawArrays(GL_TRIANGLES, 0, nv);
 	glfwSwapBuffers(window);
 	glfwPollEvents();
 	if (spin)


### PR DESCRIPTION
Before this fix, sometimes lots of bogus polygons would flicker in and out for me.

(Thank you for making this! I don't expect you to see this after seven years, but I had to try.)